### PR TITLE
🐛fix: 某些情况下获取summary数据会异常

### DIFF
--- a/telecom_class.py
+++ b/telecom_class.py
@@ -259,6 +259,9 @@ PMpq0/XKBO8lYhN/gwIDAQAB
                 )
                 item_use = self.convert_flow(item["leftTitleHh"], "KB")
                 item_balance = item_total - item_use
+            # 忽略其他不能识别的情形
+            else:
+                continue
             flowItems.append(
                 {
                     "name": item["title"],

--- a/telecom_class.py
+++ b/telecom_class.py
@@ -261,6 +261,7 @@ PMpq0/XKBO8lYhN/gwIDAQAB
                 item_balance = item_total - item_use
             # 忽略其他不能识别的情形
             else:
+                print(f"Ignore flow: {item}")
                 continue
             flowItems.append(
                 {


### PR DESCRIPTION
我自己的号码从电信接口获取到的流量信息会包含以下项目
```json
"flowList": [
    {
        "title": "国内通用流量(畅享)",
        "subTitle": "",
        "barPercent": "0",
        "barRightCount": "1个",
        "leftTitle": "已用",
        "leftTitleHh": "0KB",
        "rightTitle": "",
        "rightTitleHh": "",
        "rightTitleEnd": ""
    }
]
```

这种情况下会在尝试生成summary数据时抛出异常
```plain
File "/app/./app/api_server.py", line 129, in summary
    data = telecom.to_summary(
        json.loads(important_data.data)["responseData"]["data"]
    )
  File "/app/telecom_class.py", line 265, in to_summary
    "use": item_use,
           ^^^^^^^^
UnboundLocalError: cannot access local variable 'item_use' where it is not associated with a value
```